### PR TITLE
refactor: cleanup naming, tests, and cron improvements

### DIFF
--- a/applications/web/sources/components/Application.tsx
+++ b/applications/web/sources/components/Application.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react';
+import { type ReactNode, useEffect, useState, useCallback } from 'react';
 import styled from '@emotion/styled';
 import { usePermalink } from '../hooks/usePermalink.ts';
 import { usePopularSongsQuery } from '../hooks/usePopularSongsQuery.ts';
@@ -27,7 +27,7 @@ const MainContent = styled.main`
   }
 `;
 
-export function Application(): JSX.Element {
+export function Application(): ReactNode {
   const {
     searchForm,
     selectedSong,

--- a/applications/web/sources/components/Header/Header.tsx
+++ b/applications/web/sources/components/Header/Header.tsx
@@ -174,7 +174,14 @@ export function Header({
     <StyledHeader>
       <HeaderTop>
         <TitleGroup
-          onClick={() => { window.location.href = import.meta.env.BASE_URL; }}
+          onClick={() => {
+            const defaultRange = buildThisMonthDateRange();
+            onSearchFormChange({
+              chartType: 'TOP',
+              strType: '1',
+              ...defaultRange,
+            });
+          }}
           style={{ cursor: 'pointer' }}
         >
           <Title>TJMedia</Title>

--- a/applications/web/sources/components/Header/Header.tsx
+++ b/applications/web/sources/components/Header/Header.tsx
@@ -173,7 +173,10 @@ export function Header({
   return (
     <StyledHeader>
       <HeaderTop>
-        <TitleGroup>
+        <TitleGroup
+          onClick={() => { window.location.href = import.meta.env.BASE_URL; }}
+          style={{ cursor: 'pointer' }}
+        >
           <Title>TJMedia</Title>
           <Subtitle>Charts</Subtitle>
         </TitleGroup>

--- a/applications/web/sources/components/Player/YouTubePlayer.tsx
+++ b/applications/web/sources/components/Player/YouTubePlayer.tsx
@@ -7,7 +7,7 @@ import {
   faExclamationTriangle,
   faTimes,
 } from '@fortawesome/free-solid-svg-icons';
-import { useYoutubeSearchQuery } from '../../hooks/useYoutubeSearchQuery.ts';
+import { useYouTubeSearchQuery } from '../../hooks/useYouTubeSearchQuery.ts';
 import { useYouTubePlayer } from '../../hooks/useYouTubePlayer.ts';
 import type { PlayerState } from '../../hooks/useYouTubePlayer.ts';
 import {
@@ -66,7 +66,7 @@ export function YouTubePlayer({
     }
   }, [playerState, onPlayerStateChange]);
 
-  const { data, isPending, isError, error } = useYoutubeSearchQuery(query);
+  const { data, isPending, isError, error } = useYouTubeSearchQuery(query);
 
   const videos = data?.items ?? [];
   const currentVideo = videos[currentIndex] ?? null;

--- a/applications/web/sources/components/Root.tsx
+++ b/applications/web/sources/components/Root.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Application } from './Application.tsx';
 
@@ -10,7 +11,7 @@ const queryClient = new QueryClient({
   },
 });
 
-export function Root(): JSX.Element {
+export function Root(): ReactNode {
   return (
     <QueryClientProvider client={queryClient}>
       <Application />

--- a/applications/web/sources/components/SongList/SongItem.stories.tsx
+++ b/applications/web/sources/components/SongList/SongItem.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 
-import type { TjmediaItem } from '../../types/tjmedia.ts';
+import type { TJMediaItem } from '../../types/tjmedia.ts';
 import { SongItem } from './SongItem.tsx';
 
-const mockSong: TjmediaItem = {
+const mockSong: TJMediaItem = {
   rank: '3',
   pro: 12345,
   indexTitle: 'APT.',
@@ -15,7 +15,7 @@ const mockSong: TjmediaItem = {
   mv_yn: 'Y',
 };
 
-const firstPlaceSong: TjmediaItem = {
+const firstPlaceSong: TJMediaItem = {
   ...mockSong,
   rank: '1',
   pro: 99999,

--- a/applications/web/sources/components/SongList/SongItem.tsx
+++ b/applications/web/sources/components/SongList/SongItem.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPlay } from '@fortawesome/free-solid-svg-icons';
-import type { TjmediaItem } from '../../types/tjmedia.ts';
+import type { TJMediaItem } from '../../types/tjmedia.ts';
 import {
   StyledSongItem,
   Rank,
@@ -23,7 +23,7 @@ export function SongItem({
   isPlaying,
   onSelect,
 }: {
-  song: TjmediaItem;
+  song: TJMediaItem;
   index: number;
   isSelected: boolean;
   isPlaying: boolean;

--- a/applications/web/sources/components/SongList/SongList.stories.tsx
+++ b/applications/web/sources/components/SongList/SongList.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
 
-import type { TjmediaItem } from '../../types/tjmedia.ts';
+import type { TJMediaItem } from '../../types/tjmedia.ts';
 import { SongList } from './SongList.tsx';
 
-const mockSongs: TjmediaItem[] = [
+const mockSongs: TJMediaItem[] = [
   {
     rank: '1',
     pro: 10001,

--- a/applications/web/sources/components/SongList/SongList.tsx
+++ b/applications/web/sources/components/SongList/SongList.tsx
@@ -1,4 +1,4 @@
-import type { TjmediaItem } from '../../types/tjmedia.ts';
+import type { TJMediaItem } from '../../types/tjmedia.ts';
 import { buildChartErrorMessage } from '../../services/tjmedia.ts';
 import { Subtitle, EmptyState, ErrorMessage } from '../shared/styles.ts';
 import { ListSection, ListHeader } from './styles.ts';
@@ -14,13 +14,13 @@ export function SongList({
   isPlaying,
   onSelectSong,
 }: {
-  songs: TjmediaItem[];
+  songs: TJMediaItem[];
   isPending: boolean;
   isError: boolean;
   errorMessage: string | undefined;
-  selectedSong: TjmediaItem | null;
+  selectedSong: TJMediaItem | null;
   isPlaying: boolean;
-  onSelectSong: (song: TjmediaItem) => void;
+  onSelectSong: (song: TJMediaItem) => void;
 }) {
   return (
     <ListSection>

--- a/applications/web/sources/hooks/usePermalink.ts
+++ b/applications/web/sources/hooks/usePermalink.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react';
-import type { SearchForm, TjmediaItem } from '../types/tjmedia.ts';
+import type { SearchForm, TJMediaItem } from '../types/tjmedia.ts';
 import {
   parseSearchFormFromURL,
   parseRankFromURL,
@@ -9,10 +9,10 @@ import {
 type UsePermalinkResult = {
   searchForm: SearchForm;
   selectedRank: number | null;
-  selectedSong: TjmediaItem | null;
+  selectedSong: TJMediaItem | null;
   updateSearchForm: (next: SearchForm) => void;
-  selectSong: (song: TjmediaItem | null) => void;
-  syncSelectedSongFromData: (songs: TjmediaItem[]) => void;
+  selectSong: (song: TJMediaItem | null) => void;
+  syncSelectedSongFromData: (songs: TJMediaItem[]) => void;
 };
 
 function readInitialState(): { searchForm: SearchForm; rank: number | null } {
@@ -28,7 +28,7 @@ export function usePermalink(): UsePermalinkResult {
   const [initial] = useState(readInitialState);
   const [searchForm, setSearchForm] = useState<SearchForm>(initial.searchForm);
   const [selectedRank, setSelectedRank] = useState<number | null>(initial.rank);
-  const [selectedSong, setSelectedSong] = useState<TjmediaItem | null>(null);
+  const [selectedSong, setSelectedSong] = useState<TJMediaItem | null>(null);
 
   const updateSearchForm = useCallback((next: SearchForm) => {
     setSearchForm(next);
@@ -38,7 +38,7 @@ export function usePermalink(): UsePermalinkResult {
   }, []);
 
   const selectSong = useCallback(
-    (song: TjmediaItem | null) => {
+    (song: TJMediaItem | null) => {
       setSelectedSong(song);
       const rank = song !== null ? Number(song.rank) : null;
       setSelectedRank(rank);
@@ -48,7 +48,7 @@ export function usePermalink(): UsePermalinkResult {
   );
 
   const syncSelectedSongFromData = useCallback(
-    (songs: TjmediaItem[]) => {
+    (songs: TJMediaItem[]) => {
       if (selectedRank === null || selectedSong !== null) {
         return;
       }

--- a/applications/web/sources/hooks/usePopularSongsQuery.ts
+++ b/applications/web/sources/hooks/usePopularSongsQuery.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import type { SearchForm } from '../types/tjmedia.ts';
-import { fetchPopularSongs } from '../services/tjmedia.ts';
+import { fetchTJMediaPopularSongs } from '../services/tjmedia.ts';
 
 export function usePopularSongsQuery(searchForm: SearchForm) {
   return useQuery({
     queryKey: ['tjmedia', searchForm],
-    queryFn: () => fetchPopularSongs(searchForm),
+    queryFn: () => fetchTJMediaPopularSongs(searchForm),
   });
 }

--- a/applications/web/sources/hooks/useYouTubeSearchQuery.ts
+++ b/applications/web/sources/hooks/useYouTubeSearchQuery.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchYoutubeVideos } from '../services/youtube.ts';
+import { fetchYouTubeVideos } from '../services/youtube.ts';
 
 const FIVE_MINUTES_IN_MILLISECONDS = 5 * 60 * 1000;
 
-export function useYoutubeSearchQuery(query: string) {
+export function useYouTubeSearchQuery(query: string) {
   return useQuery({
     queryKey: ['youtube', query],
-    queryFn: () => fetchYoutubeVideos(query),
+    queryFn: () => fetchYouTubeVideos(query),
     staleTime: FIVE_MINUTES_IN_MILLISECONDS,
   });
 }

--- a/applications/web/sources/services/tjmedia.test.ts
+++ b/applications/web/sources/services/tjmedia.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { buildChartErrorMessage } from './tjmedia.ts';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildChartErrorMessage, fetchTJMediaPopularSongs } from './tjmedia.ts';
+import type { SearchForm } from '../types/tjmedia.ts';
 
 describe('buildChartErrorMessage', () => {
   it('returns specific message when error contains "resultCode 04"', () => {
@@ -69,6 +70,98 @@ describe('buildChartErrorMessage', () => {
 
     expect(result).toBe(
       'TJMedia returned an application-level failure (`resultCode 04`). Try again in a moment or change the date range.',
+    );
+  });
+});
+
+const defaultSearchForm: SearchForm = {
+  chartType: 'TOP',
+  strType: '1',
+  searchStartDate: '2026-03-01',
+  searchEndDate: '2026-03-29',
+};
+
+describe('fetchTJMediaPopularSongs', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed response on success', async () => {
+    const mockResponse = {
+      resultCode: '99',
+      resultData: { items: [{ rank: '1', indexTitle: 'Drowning' }] },
+    };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const result = await fetchTJMediaPopularSongs(defaultSearchForm);
+
+    expect(result.resultCode).toBe('99');
+    expect(result.resultData?.items?.[0].indexTitle).toBe('Drowning');
+  });
+
+  it('includes chartType and strType in search parameters', async () => {
+    const mockResponse = { resultCode: '99', resultData: { items: [] } };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), { status: 200 }),
+    );
+
+    await fetchTJMediaPopularSongs(defaultSearchForm);
+
+    const calledUrl = new URL(vi.mocked(fetch).mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get('chartType')).toBe('TOP');
+    expect(calledUrl.searchParams.get('strType')).toBe('1');
+  });
+
+  it('throws when response is not ok with worker error body', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: 'upstream failed', status: 502 } }),
+        { status: 502 },
+      ),
+    );
+
+    await expect(fetchTJMediaPopularSongs(defaultSearchForm)).rejects.toThrow('upstream failed');
+  });
+
+  it('throws generic error when response is not ok with non-JSON body', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('<html>Bad Gateway</html>', { status: 502 }),
+    );
+
+    await expect(fetchTJMediaPopularSongs(defaultSearchForm)).rejects.toThrow(
+      'TJMedia worker request failed with 502.',
+    );
+  });
+
+  it('throws when response body is invalid JSON', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('not json', { status: 200 }),
+    );
+
+    await expect(fetchTJMediaPopularSongs(defaultSearchForm)).rejects.toThrow(
+      'TJMedia worker returned invalid JSON.',
+    );
+  });
+
+  it('throws when resultCode is not 99', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ resultCode: '04', resultMsg: '알수 없는 에러' }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(fetchTJMediaPopularSongs(defaultSearchForm)).rejects.toThrow(
+      'TJMedia returned unexpected resultCode 04: 알수 없는 에러.',
     );
   });
 });

--- a/applications/web/sources/services/tjmedia.test.ts
+++ b/applications/web/sources/services/tjmedia.test.ts
@@ -88,6 +88,7 @@ describe('fetchTJMediaPopularSongs', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('returns parsed response on success', async () => {

--- a/applications/web/sources/services/tjmedia.ts
+++ b/applications/web/sources/services/tjmedia.ts
@@ -1,4 +1,4 @@
-import type { SearchForm, TjmediaResponse } from '../types/tjmedia.ts';
+import type { SearchForm, TJMediaResponse } from '../types/tjmedia.ts';
 import { isWorkerErrorResponse } from '../types/youtube.ts';
 import { isDefaultDateRange } from '../tools/search-form-storage.ts';
 
@@ -29,9 +29,9 @@ export function buildChartErrorMessage(errorMessage: string): string {
   return `Failed to load charts: ${errorMessage}`;
 }
 
-export async function fetchPopularSongs(
+export async function fetchTJMediaPopularSongs(
   searchForm: SearchForm,
-): Promise<TjmediaResponse> {
+): Promise<TJMediaResponse> {
   const tjmediaApiBaseUrl = buildTjmediaApiBaseUrl().replace(/\/$/, '');
   const searchUrl = tjmediaApiBaseUrl.startsWith('http')
     ? new URL(`${tjmediaApiBaseUrl}/search`)
@@ -65,15 +65,15 @@ export async function fetchPopularSongs(
     );
   }
 
-  let parsedResponseBody: TjmediaResponse;
+  let parsedResponseBody: TJMediaResponse;
 
   try {
-    parsedResponseBody = JSON.parse(responseText) as TjmediaResponse;
+    parsedResponseBody = JSON.parse(responseText) as TJMediaResponse;
   } catch {
     throw new Error('TJMedia worker returned invalid JSON.');
   }
 
-  const tjmediaResponse = parsedResponseBody as TjmediaResponse;
+  const tjmediaResponse = parsedResponseBody as TJMediaResponse;
 
   if (tjmediaResponse.resultCode !== '99') {
     const resultCode = tjmediaResponse.resultCode ?? 'unknown';

--- a/applications/web/sources/services/tjmedia.ts
+++ b/applications/web/sources/services/tjmedia.ts
@@ -73,15 +73,13 @@ export async function fetchTJMediaPopularSongs(
     throw new Error('TJMedia worker returned invalid JSON.');
   }
 
-  const tjmediaResponse = parsedResponseBody as TJMediaResponse;
-
-  if (tjmediaResponse.resultCode !== '99') {
-    const resultCode = tjmediaResponse.resultCode ?? 'unknown';
-    const resultMessage = tjmediaResponse.resultMsg ?? 'Unknown upstream error';
+  if (parsedResponseBody.resultCode !== '99') {
+    const resultCode = parsedResponseBody.resultCode ?? 'unknown';
+    const resultMessage = parsedResponseBody.resultMsg ?? 'Unknown upstream error';
     throw new Error(
       `TJMedia returned unexpected resultCode ${resultCode}: ${resultMessage}.`,
     );
   }
 
-  return tjmediaResponse;
+  return parsedResponseBody;
 }

--- a/applications/web/sources/services/youtube.test.ts
+++ b/applications/web/sources/services/youtube.test.ts
@@ -8,6 +8,7 @@ describe('fetchYouTubeVideos', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('returns parsed response on success', async () => {

--- a/applications/web/sources/services/youtube.test.ts
+++ b/applications/web/sources/services/youtube.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fetchYouTubeVideos } from './youtube.ts';
+
+describe('fetchYouTubeVideos', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns parsed response on success', async () => {
+    const mockResponse = {
+      query: 'Drowning WOODZ',
+      items: [{ videoId: 'abc', title: 'Drowning', thumbnailUrl: 'https://img', source: 'topic', width: 480, height: 360 }],
+    };
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(mockResponse), { status: 200 }),
+    );
+
+    const result = await fetchYouTubeVideos('Drowning WOODZ');
+
+    expect(result.query).toBe('Drowning WOODZ');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].videoId).toBe('abc');
+  });
+
+  it('includes search_query in URL parameters', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ query: 'test', items: [] }), { status: 200 }),
+    );
+
+    await fetchYouTubeVideos('아이유 밤편지');
+
+    const calledUrl = new URL(vi.mocked(fetch).mock.calls[0][0] as string);
+    expect(calledUrl.searchParams.get('search_query')).toBe('아이유 밤편지');
+  });
+
+  it('throws when response is not ok with worker error body', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({ error: { message: 'search failed', status: 502 } }),
+        { status: 502 },
+      ),
+    );
+
+    await expect(fetchYouTubeVideos('test')).rejects.toThrow('search failed');
+  });
+
+  it('throws generic error when response is not ok with non-JSON body', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('<html>Bad Gateway</html>', { status: 502 }),
+    );
+
+    await expect(fetchYouTubeVideos('test')).rejects.toThrow(
+      'YouTube worker request failed with 502.',
+    );
+  });
+
+  it('throws when response body is invalid JSON', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('not json', { status: 200 }),
+    );
+
+    await expect(fetchYouTubeVideos('test')).rejects.toThrow(
+      'YouTube worker returned invalid JSON.',
+    );
+  });
+});

--- a/applications/web/sources/services/youtube.ts
+++ b/applications/web/sources/services/youtube.ts
@@ -1,4 +1,4 @@
-import type { YoutubeResponse } from '../types/youtube.ts';
+import type { YouTubeResponse } from '../types/youtube.ts';
 import { isWorkerErrorResponse } from '../types/youtube.ts';
 
 function buildYoutubeApiBaseUrl(): string {
@@ -16,9 +16,9 @@ function buildYoutubeApiBaseUrl(): string {
   return url;
 }
 
-export async function fetchYoutubeVideos(
+export async function fetchYouTubeVideos(
   query: string,
-): Promise<YoutubeResponse> {
+): Promise<YouTubeResponse> {
   const youtubeApiBaseUrl = buildYoutubeApiBaseUrl().replace(/\/$/, '');
   const searchUrl = youtubeApiBaseUrl.startsWith('http')
     ? new URL(`${youtubeApiBaseUrl}/search`)
@@ -46,10 +46,10 @@ export async function fetchYoutubeVideos(
     );
   }
 
-  let parsedResponseBody: YoutubeResponse;
+  let parsedResponseBody: YouTubeResponse;
 
   try {
-    parsedResponseBody = JSON.parse(responseText) as YoutubeResponse;
+    parsedResponseBody = JSON.parse(responseText) as YouTubeResponse;
   } catch {
     throw new Error('YouTube worker returned invalid JSON.');
   }

--- a/applications/web/sources/tools/dates.test.ts
+++ b/applications/web/sources/tools/dates.test.ts
@@ -1,27 +1,26 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildTodayDateRange, buildThisMonthDateRange } from './dates.ts';
 
-function formatLocalDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-03-15T12:00:00'));
+});
 
-  return `${year}-${month}-${day}`;
-}
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe('buildTodayDateRange', () => {
   it('returns searchStartDate as yesterday', () => {
     const result = buildTodayDateRange();
-    const now = new Date();
-    const yesterday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1);
 
-    expect(result.searchStartDate).toBe(formatLocalDate(yesterday));
+    expect(result.searchStartDate).toBe('2026-03-14');
   });
 
   it('returns searchEndDate as today', () => {
     const result = buildTodayDateRange();
 
-    expect(result.searchEndDate).toBe(formatLocalDate(new Date()));
+    expect(result.searchEndDate).toBe('2026-03-15');
   });
 
   it('returns dates in YYYY-MM-DD format', () => {
@@ -40,21 +39,27 @@ describe('buildTodayDateRange', () => {
 
     expect(differenceInDays).toBe(1);
   });
+
+  it('handles month boundary correctly', () => {
+    vi.setSystemTime(new Date('2026-04-01T12:00:00'));
+    const result = buildTodayDateRange();
+
+    expect(result.searchStartDate).toBe('2026-03-31');
+    expect(result.searchEndDate).toBe('2026-04-01');
+  });
 });
 
 describe('buildThisMonthDateRange', () => {
   it('returns searchStartDate as the first day of the current month', () => {
     const result = buildThisMonthDateRange();
-    const now = new Date();
-    const expectedStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
-    expect(result.searchStartDate).toBe(formatLocalDate(expectedStart));
+    expect(result.searchStartDate).toBe('2026-03-01');
   });
 
   it('returns searchEndDate as today', () => {
     const result = buildThisMonthDateRange();
 
-    expect(result.searchEndDate).toBe(formatLocalDate(new Date()));
+    expect(result.searchEndDate).toBe('2026-03-15');
   });
 
   it('returns dates in YYYY-MM-DD format', () => {

--- a/applications/web/sources/tools/permalink.test.ts
+++ b/applications/web/sources/tools/permalink.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   parseSearchFormFromURL,
   parseRankFromURL,
   buildSearchParameters,
   buildPermalinkURL,
+  pushPermalink,
 } from './permalink.ts';
 import { buildThisMonthDateRange } from './dates.ts';
 import type { SearchForm } from '../types/tjmedia.ts';
@@ -340,5 +341,54 @@ describe('buildPermalinkURL', () => {
     expect(result).toContain('to=2024-07-31');
     expect(result).toContain('rank=10');
     expect(result).toMatch(/^\/tjmedia-popular-youtube\/\?/);
+  });
+});
+
+describe('pushPermalink', () => {
+  it('calls history.pushState with the permalink URL', () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const defaultDateRange = buildThisMonthDateRange();
+    const searchForm: SearchForm = {
+      chartType: 'TOP',
+      strType: '2',
+      searchStartDate: defaultDateRange.searchStartDate,
+      searchEndDate: defaultDateRange.searchEndDate,
+    };
+
+    pushPermalink(searchForm, 5);
+
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      expect.stringContaining('type=english'),
+    );
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      expect.stringContaining('rank=5'),
+    );
+
+    pushStateSpy.mockRestore();
+  });
+
+  it('calls history.pushState with base path for defaults', () => {
+    const pushStateSpy = vi.spyOn(window.history, 'pushState');
+    const defaultDateRange = buildThisMonthDateRange();
+    const searchForm: SearchForm = {
+      chartType: 'TOP',
+      strType: '1',
+      searchStartDate: defaultDateRange.searchStartDate,
+      searchEndDate: defaultDateRange.searchEndDate,
+    };
+
+    pushPermalink(searchForm, null);
+
+    expect(pushStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      '/tjmedia-popular-youtube/',
+    );
+
+    pushStateSpy.mockRestore();
   });
 });

--- a/applications/web/sources/types/tjmedia.ts
+++ b/applications/web/sources/types/tjmedia.ts
@@ -8,7 +8,7 @@ export type SearchForm = {
   strType: GenreType;
 };
 
-export type TjmediaItem = {
+export type TJMediaItem = {
   rank: string;
   pro: number;
   indexTitle: string;
@@ -19,10 +19,10 @@ export type TjmediaItem = {
   mv_yn: string;
 };
 
-export type TjmediaResponse = {
+export type TJMediaResponse = {
   resultCode: string;
   resultMsg?: string;
   resultData?: {
-    items?: TjmediaItem[];
+    items?: TJMediaItem[];
   };
 };

--- a/applications/web/sources/types/youtube.test.ts
+++ b/applications/web/sources/types/youtube.test.ts
@@ -47,4 +47,20 @@ describe('isWorkerErrorResponse', () => {
 
     expect(isWorkerErrorResponse(response)).toBe(true);
   });
+
+  it('returns false for string primitive', () => {
+    expect(isWorkerErrorResponse('error')).toBe(false);
+  });
+
+  it('returns false for number primitive', () => {
+    expect(isWorkerErrorResponse(42)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isWorkerErrorResponse(undefined)).toBe(false);
+  });
+
+  it('returns false for boolean', () => {
+    expect(isWorkerErrorResponse(true)).toBe(false);
+  });
 });

--- a/applications/web/sources/types/youtube.ts
+++ b/applications/web/sources/types/youtube.ts
@@ -1,4 +1,4 @@
-export type YoutubeItem = {
+export type YouTubeItem = {
   videoId: string;
   title: string;
   thumbnailUrl: string;
@@ -7,9 +7,9 @@ export type YoutubeItem = {
   height: number;
 };
 
-export type YoutubeResponse = {
+export type YouTubeResponse = {
   query: string;
-  items: YoutubeItem[];
+  items: YouTubeItem[];
 };
 
 export type WorkerErrorResponse = {

--- a/applications/web/tsconfig.json
+++ b/applications/web/tsconfig.json
@@ -20,7 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./sources/*"]
     },

--- a/workers/tjmedia-popular-worker/tests/worker.test.ts
+++ b/workers/tjmedia-popular-worker/tests/worker.test.ts
@@ -575,8 +575,11 @@ describe('scheduled handler', () => {
 
     await Promise.all(waitUntilPromises);
 
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(r2Bucket.put).toHaveBeenCalledTimes(3);
+    // 3 strTypes × 2 (daily + this month) = 6
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(r2Bucket.put).toHaveBeenCalledTimes(6);
+
+    // Daily archive
     expect(r2Bucket.put).toHaveBeenCalledWith(
       'cache/2026-03-21_2026-03-21/strType-1.json',
       buildSuccessUpstreamBody(),
@@ -587,6 +590,20 @@ describe('scheduled handler', () => {
     );
     expect(r2Bucket.put).toHaveBeenCalledWith(
       'cache/2026-03-21_2026-03-21/strType-3.json',
+      buildSuccessUpstreamBody(),
+    );
+
+    // This month cache
+    expect(r2Bucket.put).toHaveBeenCalledWith(
+      'cache/2026-03-01_2026-03-21/strType-1.json',
+      buildSuccessUpstreamBody(),
+    );
+    expect(r2Bucket.put).toHaveBeenCalledWith(
+      'cache/2026-03-01_2026-03-21/strType-2.json',
+      buildSuccessUpstreamBody(),
+    );
+    expect(r2Bucket.put).toHaveBeenCalledWith(
+      'cache/2026-03-01_2026-03-21/strType-3.json',
       buildSuccessUpstreamBody(),
     );
 
@@ -634,9 +651,9 @@ describe('scheduled handler', () => {
 
     await Promise.all(waitUntilPromises);
 
-    // strType 1 returned 04 (no retry for server errors), but 2 and 3 succeeded
-    expect(fetchMock).toHaveBeenCalledTimes(3);
-    expect(r2Bucket.put).toHaveBeenCalledTimes(2);
+    // strType 1 daily returned 04, remaining 5 calls succeeded
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(r2Bucket.put).toHaveBeenCalledTimes(5);
 
     vi.useRealTimers();
   });

--- a/workers/tjmedia-popular-worker/worker.ts
+++ b/workers/tjmedia-popular-worker/worker.ts
@@ -26,7 +26,7 @@ type WorkerEnvironment = {
   R2_TJMEDIA_POPULAR: R2Bucket;
 };
 
-type TjmediaSearchResponse = {
+type TJMediaSearchResponse = {
   resultCode?: string;
   resultMsg?: string;
   resultData?: {
@@ -158,7 +158,7 @@ function validateUpstreamResponse(
   upstreamContentType: string,
   upstreamStatus: number,
   origin?: string,
-): { parsedBody: TjmediaSearchResponse; errorResponse?: Response } {
+): { parsedBody: TJMediaSearchResponse; errorResponse?: Response } {
   if (!upstreamContentType.toLowerCase().includes('application/json')) {
     return {
       parsedBody: {},
@@ -170,10 +170,10 @@ function validateUpstreamResponse(
     };
   }
 
-  let parsedBody: TjmediaSearchResponse;
+  let parsedBody: TJMediaSearchResponse;
 
   try {
-    parsedBody = JSON.parse(upstreamBody) as TjmediaSearchResponse;
+    parsedBody = JSON.parse(upstreamBody) as TJMediaSearchResponse;
   } catch {
     return {
       parsedBody: {},

--- a/workers/tjmedia-popular-worker/worker.ts
+++ b/workers/tjmedia-popular-worker/worker.ts
@@ -62,12 +62,21 @@ function formatDateString(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function toKST(date: Date): Date {
+  return new Date(date.getTime() + 9 * 60 * 60 * 1000);
+}
+
 function getYesterdayKSTDateString(): string {
-  const now = new Date();
-  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const kst = toKST(new Date());
   kst.setUTCDate(kst.getUTCDate() - 1);
 
   return formatDateString(kst);
+}
+
+function getFirstDayOfMonthKSTDateString(): string {
+  const kst = toKST(new Date());
+
+  return `${kst.getUTCFullYear()}-${String(kst.getUTCMonth() + 1).padStart(2, '0')}-01`;
 }
 
 function getDebugMockMode(environment: WorkerEnvironment): DebugMockMode {
@@ -308,14 +317,15 @@ function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function crawlStrType(
+async function crawlAndStore(
   strType: string,
-  date: string,
+  startDate: string,
+  endDate: string,
   environment: WorkerEnvironment,
 ): Promise<boolean> {
   const searchParameters = new URLSearchParams();
-  searchParameters.set('searchStartDate', date);
-  searchParameters.set('searchEndDate', date);
+  searchParameters.set('searchStartDate', startDate);
+  searchParameters.set('searchEndDate', endDate);
   searchParameters.set('chartType', CRAWL_CHART_TYPE);
   searchParameters.set('strType', strType);
 
@@ -327,52 +337,69 @@ async function crawlStrType(
   );
 
   if (validation.errorResponse !== undefined) {
-    console.error(`Scheduled crawl failed for strType ${strType}: upstream returned error.`);
+    console.error(`Scheduled crawl failed for strType ${strType} (${startDate}_${endDate}): upstream returned error.`);
     return false;
   }
 
   if (validation.parsedBody.resultCode !== RESULT_CODE.SUCCESS) {
     console.error(
-      `Scheduled crawl skipped for strType ${strType}: resultCode ${validation.parsedBody.resultCode ?? 'unknown'}.`,
+      `Scheduled crawl skipped for strType ${strType} (${startDate}_${endDate}): resultCode ${validation.parsedBody.resultCode ?? 'unknown'}.`,
     );
     return false;
   }
 
-  const cacheKey = `cache/${date}_${date}/strType-${strType}.json`;
+  const cacheKey = `cache/${startDate}_${endDate}/strType-${strType}.json`;
   await environment.R2_TJMEDIA_POPULAR.put(cacheKey, JSON.stringify(validation.parsedBody));
   console.log(`Scheduled crawl succeeded for strType ${strType}: stored at ${cacheKey}.`);
 
   return true;
 }
 
+async function crawlWithRetry(
+  strType: string,
+  startDate: string,
+  endDate: string,
+  environment: WorkerEnvironment,
+): Promise<void> {
+  const label = `${startDate}_${endDate}`;
+
+  for (let attempt = 1; attempt <= CRAWL_MAX_RETRIES; attempt++) {
+    try {
+      const succeeded = await crawlAndStore(strType, startDate, endDate, environment);
+      // Whether true or false, the upstream responded — no need to retry
+      if (!succeeded) {
+        console.error(`Scheduled crawl gave up for strType ${strType} (${label}): upstream returned non-success.`);
+      }
+      return;
+    } catch (error) {
+      // Network error or unexpected failure — retry
+      console.error(
+        `Scheduled crawl failed for strType ${strType} (${label}) (attempt ${attempt}/${CRAWL_MAX_RETRIES}):`,
+        error,
+      );
+
+      if (attempt < CRAWL_MAX_RETRIES) {
+        await delay(CRAWL_RETRY_DELAY_MILLISECONDS);
+      }
+    }
+  }
+
+  console.error(`Scheduled crawl gave up for strType ${strType} (${label}) after ${CRAWL_MAX_RETRIES} attempts.`);
+}
+
 async function handleScheduledEvent(
   environment: WorkerEnvironment,
 ): Promise<void> {
   const yesterday = getYesterdayKSTDateString();
+  const firstDayOfMonth = getFirstDayOfMonthKSTDateString();
 
   for (const strType of CRAWL_STR_TYPES) {
-    let succeeded = false;
+    // Daily archive: yesterday only
+    await crawlWithRetry(strType, yesterday, yesterday, environment);
 
-    for (let attempt = 1; attempt <= CRAWL_MAX_RETRIES; attempt++) {
-      try {
-        succeeded = await crawlStrType(strType, yesterday, environment);
-        // Whether true or false, the upstream responded — no need to retry
-        break;
-      } catch (error) {
-        // Network error or unexpected failure — retry
-        console.error(
-          `Scheduled crawl failed for strType ${strType} (attempt ${attempt}/${CRAWL_MAX_RETRIES}):`,
-          error,
-        );
-
-        if (attempt < CRAWL_MAX_RETRIES) {
-          await delay(CRAWL_RETRY_DELAY_MILLISECONDS);
-        }
-      }
-    }
-
-    if (!succeeded) {
-      console.error(`Scheduled crawl gave up for strType ${strType} after ${CRAWL_MAX_RETRIES} attempts.`);
+    // This month cache: 1st of month to yesterday
+    if (firstDayOfMonth !== yesterday) {
+      await crawlWithRetry(strType, firstDayOfMonth, yesterday, environment);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Title 클릭 시 홈으로 이동
- Cron에 이번 달 캐시 추가 (daily archive + this-month 캐시)
- 네이밍 컨벤션 정리 (YouTube, TJMedia 대문자 축약어)
- fetchTJMediaPopularSongs, fetchYouTubeVideos 서비스 함수 테스트 추가
- TypeScript 6 baseUrl deprecation 해결
- JSX.Element → ReactNode (React 19 + TS6)
- 날짜 테스트 fake timer 적용
- pushPermalink, isWorkerErrorResponse primitive 테스트 추가

## Test plan
- [ ] 90개 web 테스트 통과
- [ ] 23개 tjmedia worker 테스트 통과
- [ ] tsc --noEmit 에러 없음
- [ ] Storybook 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 헤더의 제목을 클릭하면 홈페이지로 이동합니다.

* **테스트**
  * 서비스, 유틸리티, 퍼머링크, 날짜 처리 및 외부 API 관련 테스트를 대폭 확장해 안정성을 향상했습니다.

* **리팩토링**
  * 타입 및 명명 규칙을 정리해 코드 일관성을 개선했습니다.

* **기타**
  * 백엔드 크롤링 범위가 확장되고 캐시 생성 방식이 강화되어 데이터 갱신 및 보관 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->